### PR TITLE
Fix GitHub stats images

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@
 ## 📈 GitHub Stats
 
 <p align="center">
-  <img src="https://github-readme-stats.vercel.app/api?username=mohammadaminml&show_icons=true&theme=default" />
+  <img src="https://github-readme-stats.vercel.app/api?username=mohammadaminml&show_icons=true&theme=default" alt="GitHub Stats" />
   <br />
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=mohammadaminml&layout=compact" />
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=mohammadaminml&layout=compact" alt="Top Languages" />
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- add missing alt text for the GitHub stats images

## Testing
- `markdownlint README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68868c16321c8321a99c4adefe9aea8d